### PR TITLE
Add `arm64` support

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -15,6 +15,9 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
     - name: Compile and extract artifacts from docker container
       run: |
         mkdir -p dist

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -15,9 +15,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
-
     - name: Compile and extract artifacts from docker container
       run: |
         mkdir -p dist

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -14,12 +14,18 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
+    
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
 
-    - name: Compile and extract the artifact from docker container
+    - name: Compile and extract artifacts from docker container
       run: |
         mkdir -p dist
-        docker build -t alpine:libfuse -f Dockerfile.alpine .
-        docker run --rm -v $(pwd):/workdir alpine:libfuse cp /libfuse/dist/libfuse.a /workdir/dist
+
+        for arch in x86_64 aarch64; do
+          docker build --platform "${arch}" -t alpine:libfuse -f Dockerfile.alpine .
+          docker run --rm --platform "${arch}" -v $(pwd):/workdir alpine:libfuse cp /libfuse/dist/libfuse.a "/workdir/dist/libfuse-${arch}.a"
+        done
 
     - name: Set permissions for dist directory
       run: |

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -32,7 +32,7 @@ jobs:
         sudo chown -R "$(id -u)":"$(id -g)" dist/
         sudo chmod -R 766 dist/
 
-    - name: Upload artifact to release
+    - name: Upload artifacts to release
       uses: actions/upload-artifact@v1.0.0
       with:
         name: libfuse


### PR DESCRIPTION
This adds releases for the `arm64` architecture, to allow for https://github.com/ruanformigoni/flatimage/issues/16.